### PR TITLE
Make .new and #action private to enforce API

### DIFF
--- a/lib/procto.rb
+++ b/lib/procto.rb
@@ -59,7 +59,7 @@ class Procto < Module
   #
   # @api private
   def initialize(name)
-    @block = ->(*args) { new(*args).public_send(name) }
+    @block = ->(*args) { new(*args).__send__(name) }
   end
 
   private
@@ -75,6 +75,12 @@ class Procto < Module
   def included(host)
     host.instance_exec(@block) do |block|
       define_singleton_method(:call, &block)
+
+      private_class_method :new
+
+      def self.method_added(method_name)
+        private method_name
+      end
     end
 
     host.extend(ClassMethods)

--- a/spec/unit/procto/procto_spec.rb
+++ b/spec/unit/procto/procto_spec.rb
@@ -1,0 +1,49 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+describe Procto, '.new' do
+  subject { klass.new(1) }
+
+  let(:klass) do
+    Class.new do
+      include Procto.call
+
+      def initialize(text)
+        @text = text
+      end
+
+      def call
+        "Hello #{@text}"
+      end
+    end
+  end
+
+  it 'is a private method' do
+    expect { subject }.to raise_error(NoMethodError, /private method `new'/)
+  end
+end
+
+
+describe Procto, '#action' do
+  subject { klass.call("world").print }
+
+  let(:name) { :print }
+  let(:klass) do
+    Class.new do
+      include Procto.call(:print)
+
+      def initialize(text)
+        @text = text
+      end
+
+      def print
+        self
+      end
+    end
+  end
+
+  it 'is a private method' do
+    expect { subject }.to raise_error(NoMethodError, /private method `#{name}'/)
+  end
+end


### PR DESCRIPTION
All instance methods will be private, that is enforcing the API
defined by class method 'call'.

This changes was discussed in #6 .